### PR TITLE
Rake Delete Items Working - Do Not Merge Unless Correct

### DIFF
--- a/lib/tasks/todo.rake
+++ b/lib/tasks/todo.rake
@@ -1,0 +1,6 @@
+namespace :todo do
+  desc "Automatically deletes items that are older than 7 days"
+  task delete_items: :environment do
+    Item.where("created_at <= ?", Time.now - 7.days).destroy_all
+  end
+end


### PR DESCRIPTION
@bjblock - I created the rake that the checkpoint requested. I created a few items, changed their `created_at` attribute to "later than 7 days" inside the console, ran `rake todo:delete_items` and those items were successfully deleted. But is that all this checkpoint is wanting? Am I supposed to implement the rake command to automatically do that somehow instead of having to manually do it inside the terminal? I'm holding off on merging until I hear from you just in case. Thanks!
